### PR TITLE
Fix: /me API 응답 구조에 맞게 fetchCurrentUser 반환값 수정

### DIFF
--- a/src/RTK/authSlice.ts
+++ b/src/RTK/authSlice.ts
@@ -53,8 +53,8 @@ export const fetchCurrentUser = createAsyncThunk(
   'auth/fetchCurrentUser',
   async (_, { rejectWithValue }) => {
     try {
-      const response = await authAPI.getCurrentUser();
-      return response.account;
+      const user = await authAPI.getCurrentUser();
+      return user;
     } catch (error: any) {
       return rejectWithValue(error.response?.data?.message || '사용자 정보 조회에 실패했습니다.');
     }


### PR DESCRIPTION
MyProfile.tsx에서 테스트해볼 수 있는 코드:

```tsx
  const dispatch = useAppDispatch();
  const navigate = useNavigate();
  const isLoggedIn = useSelector((state: RootState) => state.auth.isLoggedIn);
  const user = useSelector((state: RootState) => state.auth.user);

  // API 호출과 상태 업데이트 과정을 확인하기 위한 테스트 코드
  useEffect(() => {
    const checkUser = async () => {
      const token = localStorage.getItem('accessToken');
      console.log('Token exists:', !!token);

      if (token) {
        try {
          console.log('Fetching user data...');
          const result = await dispatch(fetchCurrentUser()).unwrap();
          console.log('Fetch success:', result);
        } catch (error) {
          console.error('Fetch error:', error);
          navigate('/login');
        }
      } else {
        navigate('/login');
      }
    };

    checkUser();
  }, [dispatch, navigate]);

  console.log('isLoggedIn:', isLoggedIn);
  console.log('user:', user);```